### PR TITLE
Fix remaining nerdfont v3 icons

### DIFF
--- a/lua/nvim-web-devicons-light.lua
+++ b/lua/nvim-web-devicons-light.lua
@@ -1,6 +1,6 @@
 local icons_by_filename = {
   [".babelrc"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#666620",
     cterm_color = "58",
     name = "Babelrc",
@@ -822,7 +822,7 @@ local icons_by_file_extension = {
     name = "Json",
   },
   ["json5"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#666620",
     cterm_color = "58",
     name = "Json5",
@@ -1014,7 +1014,7 @@ local icons_by_file_extension = {
     name = "PackedResource",
   },
   ["pdf"] = {
-    icon = "",
+    icon = "",
     color = "#b30b00",
     cterm_color = "124",
     name = "Pdf",
@@ -1547,7 +1547,7 @@ local icons_by_file_extension = {
     name = "Lock",
   },
   ["log"] = {
-    icon = "",
+    icon = "󰌱",
     color = "#333333",
     cterm_color = "236",
     name = "Log",

--- a/lua/nvim-web-devicons.lua
+++ b/lua/nvim-web-devicons.lua
@@ -1,7 +1,7 @@
 -- exact match by file name
 local icons_by_filename = {
   [".babelrc"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#cbcb41",
     cterm_color = "185",
     name = "Babelrc",
@@ -824,7 +824,7 @@ local icons_by_file_extension = {
     name = "Json",
   },
   ["json5"] = {
-    icon = "ﬥ",
+    icon = "",
     color = "#cbcb41",
     cterm_color = "185",
     name = "Json5",
@@ -1016,7 +1016,7 @@ local icons_by_file_extension = {
     name = "PackedResource",
   },
   ["pdf"] = {
-    icon = "",
+    icon = "",
     color = "#b30b00",
     cterm_color = "124",
     name = "Pdf",
@@ -1549,7 +1549,7 @@ local icons_by_file_extension = {
     name = "Lock",
   },
   ["log"] = {
-    icon = "",
+    icon = "󰌱",
     color = "#ffffff",
     cterm_color = "231",
     name = "Log",


### PR DESCRIPTION
Running the following suggested these icons also need updating to be compatible with nerdfont v3

```bash
nerdfix fix lua/nvim-web-devicons.lua lua/nvim-web-devicons-light.lua
```